### PR TITLE
CDC implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ libraryDependencies += "com.precog" %% "quasar-destination-gbq" % <version>
   },
   "config": {
     "authCfg": <service-account-json-auth-file-contents>,
-    "datasetId": <dataset-name>
+    "datasetId": <dataset-name>,
+    "maxFileSize": Number?
   }
 }
 ```
@@ -24,6 +25,7 @@ libraryDependencies += "com.precog" %% "quasar-destination-gbq" % <version>
 - `destination-name` is what you would like to name the destination
 - `service-account-json-auth-file-contents` is the contents of your service account authentication json file in string format
 - `dataset-name` is the dataset name you would like your table to be pushed into
+- `maxFileSize` is optional parameter, default to 2^30, determines size of streams uploaded to BigQuery as files, e.g. by default 30Gb stream will be uploaded as 30 files.
 
 ## Testing
 

--- a/core/src/main/scala/quasar/destination/gbq/Event.scala
+++ b/core/src/main/scala/quasar/destination/gbq/Event.scala
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.gbq
+
+import slamdata.Predef._
+
+import quasar.connector._
+
+import cats.effect.Concurrent
+import cats.effect.concurrent.{Ref, Semaphore}
+import cats.implicits._
+
+import fs2.{Pipe, Stream, Pull, Chunk}
+import fs2.concurrent.Queue
+
+sealed trait Event[+F[_], +A]
+
+object Event {
+  type Nothing1[A] = Nothing
+
+  final case class Commit[A](value: A) extends Event[Nothing1, A]
+  final case class Create[F[_]](value: Stream[F, Byte]) extends Event[F, Nothing]
+  final case class Delete(value: IdBatch) extends Event[Nothing1, Nothing]
+
+  sealed trait RefQ[F[_]] {
+    def consume(chunk: Chunk[Byte]): F[Option[Stream[F, Byte]]]
+    def emit: F[Option[Stream[F, Byte]]]
+  }
+
+  object RefQ {
+    def apply[F[_]: Concurrent](maxSize: Long): F[RefQ[F]] = for {
+      q <- Queue.unbounded[F, Option[Chunk[Byte]]]
+      ref <- Ref.of[F, Queue[F, Option[Chunk[Byte]]]](q)
+      size <- Ref.of[F, Long](0L)
+      semaphore <- Semaphore[F](1)
+    } yield new RefQ[F] {
+      // RefQ.emit and RefQ.consume must not run simultaneously
+      // because they both modify refs
+      // But consuming could emit stream if it's bigger than maxSize
+      def consume(chunk: Chunk[Byte]): F[Option[Stream[F, Byte]]] =
+        semaphore.withPermit { consume0(chunk) }
+      def emit: F[Option[Stream[F, Byte]]] =
+        semaphore.withPermit { emit0 }
+
+      def emit0: F[Option[Stream[F, Byte]]] = for {
+        q <- ref.get
+        _ <- q.enqueue1(None)
+        nq <- Queue.unbounded[F, Option[Chunk[Byte]]]
+        _ <- ref.set(nq)
+        s <- size.getAndSet(0L)
+      } yield if (s > 0) {
+        q.dequeue.unNoneTerminate.flatMap(Stream.chunk).some
+      } else {
+        None
+      }
+
+      def consume0(chunk: Chunk[Byte]): F[Option[Stream[F, Byte]]] = for {
+        q <- ref.get
+        _ <- q.enqueue1(Some(chunk))
+        newSize <- size.updateAndGet(_ + chunk.size)
+        res <- if (newSize > maxSize) {
+          emit0
+        } else {
+          None.pure[F]
+        }
+      } yield res
+    }
+  }
+
+  def fromDataEvent[F[_]: Concurrent, A](maxSize: Long): Pipe[F, DataEvent[Byte, A], Event[F, A]] = {
+    def go(refQ: RefQ[F], inp: Stream[F, DataEvent[Byte, A]]): Pull[F, Event[F, A], Unit] =
+      inp.pull.uncons1 flatMap {
+        case Some((de, tail)) =>
+          val pullAction = de match {
+            case DataEvent.Create(chunk) =>
+              for {
+                mbStream <- Pull.eval(refQ.consume(chunk))
+                _ <- mbStream.traverse_(s => Pull.output1(Event.Create(s)))
+              } yield ()
+
+            case DataEvent.Delete(ids) =>
+              Pull.output1(Event.Delete(ids))
+
+            case DataEvent.Commit(offset) =>
+              for {
+                mbStream <- Pull.eval(refQ.emit)
+                _ <- mbStream.traverse_(s => Pull.output1(Event.Create(s)))
+                _ <- Pull.output1(Event.Commit(offset))
+              } yield ()
+          }
+          pullAction >> go(refQ, tail)
+        case None =>
+          Pull.done
+      }
+    inp => for {
+      refQ <- Stream.eval(RefQ[F](maxSize))
+      results <- go(refQ, inp).stream
+    } yield results
+  }
+
+  def fromByteStream[F[_]: Concurrent](maxSize: Long): Pipe[F, Byte, Event[F, Unit]] = {
+    def go(refQ: RefQ[F], inp: Stream[F, Byte]): Pull[F, Event[F, Unit], Unit] =
+      inp.pull.uncons flatMap {
+        case Some((chunk, tail)) =>
+          for {
+            mbStream <- Pull.eval(refQ.consume(chunk))
+            _ <- mbStream.traverse_(s => Pull.output1(Event.Create(s)))
+            res <- go(refQ, tail)
+          } yield res
+        case None =>
+          for {
+            mbStream <- Pull.eval(refQ.emit)
+            _ <- mbStream.traverse_(s => Pull.output1(Event.Create(s)))
+            _ <- Pull.done
+          } yield ()
+      }
+
+    inp => for {
+      refQ <- Stream.eval(RefQ[F](maxSize))
+      results <- go(refQ, inp).stream
+    } yield results
+  }
+}

--- a/core/src/main/scala/quasar/destination/gbq/Flow.scala
+++ b/core/src/main/scala/quasar/destination/gbq/Flow.scala
@@ -16,22 +16,12 @@
 
 package quasar.destination.gbq
 
-import scala.Predef.String
+import slamdata.Predef._
 
-import argonaut._, Argonaut._
+import fs2.{Stream, Pipe}
+import quasar.connector.IdBatch
 
-final case class GBQDatasetConfig(projectId: String, datasetId: String)
-
-object GBQDatasetConfig {
-  implicit val codecJson: CodecJson[GBQDatasetConfig] =
-    CodecJson(
-      (g: GBQDatasetConfig) => Json.obj(
-        "datasetReference" := Json.obj(
-          "projectId" := g.projectId,
-          "datasetId" := g.datasetId
-        )),
-      c => for {
-        projectId <- (c --\ "datasetReference" --\ "projectId").as[String]
-        datasetId <- (c --\ "datasetReference" --\ "datasetId").as[String]
-      } yield GBQDatasetConfig(projectId, datasetId))
+trait Flow[F[_]] {
+  def ingest: Pipe[F, Byte, Unit]
+  def delete(ids: IdBatch): Stream[F, Unit]
 }

--- a/core/src/main/scala/quasar/destination/gbq/GBQDestination.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQDestination.scala
@@ -16,231 +16,61 @@
 
 package quasar.destination.gbq
 
-import scala.Predef._
-
-import quasar.api.{Column, ColumnType}
+import quasar.api.ColumnType
 import quasar.api.destination.{DestinationError, DestinationType}
 import quasar.api.destination.DestinationError.InitializationError
-import quasar.api.resource.ResourceName
-import quasar.connector.{MonadResourceErr, ResourceError}
+import quasar.connector.MonadResourceErr
 import quasar.connector.destination.{Destination, LegacyDestination, ResultSink}
-import quasar.connector.render.RenderConfig
 
 import argonaut._, Argonaut._
 
-import cats.ApplicativeError
-import cats.data.{EitherT, ValidatedNel, NonEmptyList}
-import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, Resource, Sync}
+import cats.data.{EitherT, NonEmptyList}
+import cats.effect.{Concurrent, ConcurrentEffect, ContextShift, Resource}
 import cats.implicits._
-
-import fs2.{Pipe, Stream}
 
 import org.http4s.{
   AuthScheme,
   Credentials,
-  EntityEncoder,
-  MediaType,
   Method,
   Request,
-  Status,
-  Uri
+  Status
 }
-import org.http4s.argonaut.jsonEncoderOf
 import org.http4s.client._
-import org.http4s.Header
-import org.http4s.headers.{Authorization, `Content-Type`, Location}
+import org.http4s.headers.Authorization
 import org.slf4s.Logging
 
-import scalaz.{NonEmptyList => ZNEList}
-
 import scala.{
-  Byte,
   Either,
-  Some,
   StringContext,
   Unit
 }
-import scala.util.{Left, Right}
-
-import java.lang.{RuntimeException, Throwable}
 
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
-import scalaz.{NonEmptyList => ZNEList}
-
 
 class GBQDestination[F[_]: Concurrent: ContextShift: MonadResourceErr: ConcurrentEffect] private (
     client: Client[F],
-    config: GBQConfig,
-    sanitizedConfig: Json) extends LegacyDestination[F] with Logging {
+    config: GBQConfig)
+    extends LegacyDestination[F]
+    with GBQSinks[F]
+    with Logging {
 
   def destinationType: DestinationType =
      GBQDestinationModule.destinationType
 
+  def flowF(args: GBQSinks.Args) = GBQFlow(config, client, args)
+
   def sinks: NonEmptyList[ResultSink[F, ColumnType.Scalar]] =
-    NonEmptyList.one(csvSink)
+    flowSinks
 
-  val gbqRenderConfig: RenderConfig.Csv =
-    RenderConfig.Csv(
-      includeHeader = true,
-      numericScale = Some(9)) // NUMERIC data type supports inserting data of up to scale 9
-
-  private def csvSink: ResultSink[F, ColumnType.Scalar] =
-    ResultSink.create[F, ColumnType.Scalar, Byte] { (path, columns) =>
-      val tableNameF = path.uncons match {
-        case Some((ResourceName(name), _)) => name.pure[F]
-        case _ => MonadResourceErr[F].raiseError[String](
-          ResourceError.notAResource(path))
-      }
-
-      val pipe: Pipe[F, Byte, Unit] = bytes => for {
-        tableName <- Stream.eval[F, String](tableNameF)
-        schema <- Stream.fromEither[F](ensureValidColumns(columns).leftMap(new RuntimeException(_)))
-        gbqJobConfig = formGBQJobConfig(schema, config, tableName)
-        accessToken <- Stream.eval(GBQAccessToken.token(config.serviceAccountAuthBytes))
-        _ <- Stream.eval(mkDataset(client, accessToken.getTokenValue, config))
-        eitherloc <- Stream.eval(mkGbqJob(client, accessToken.getTokenValue, gbqJobConfig))
-        _ <- Stream.eval(
-          Sync[F].delay(
-            log.info(s"(re)creating ${config.authCfg.projectId}.${config.datasetId}.${tableName} with schema ${columns.show}")))
-        _ <- eitherloc match {
-          case Right(locationUri) => upload(client, bytes, locationUri)
-          case Left(e) => Stream.raiseError[F](new RuntimeException(s"No Location URL from returned from job: $e"))
-        }
-      } yield ()
-
-      (gbqRenderConfig, pipe)
-  }
-
-  // NB: config overwrites when re-pushing tables
-  // see schemaUpdateOptions section at
-  // https://cloud.google.com/bigquery/docs/reference/rest/v2/Job
-  private def formGBQJobConfig(
-      schema: NonEmptyList[GBQSchema],
-      config: GBQConfig,
-      tableId: String)
-      : GBQJobConfig =
-    GBQJobConfig(
-      "CSV",
-      1,
-      true,
-      schema.toList,
-      "DAY",
-      WriteDisposition("WRITE_TRUNCATE"), // default is to drop and replace tables when pushing
-      GBQDestinationTable(config.authCfg.projectId, config.datasetId, tableId),
-      21600000, // 6hrs load job limit
-      "LOAD")
-
-  def mkErrorString(errs: NonEmptyList[ColumnType.Scalar]): String =
-    errs
-      .map(err => s"Column of type ${err.show} is not supported by Avalanche")
-      .intercalate(", ")
-
-  private def ensureValidColumns(columns: NonEmptyList[Column[ColumnType.Scalar]]): Either[String, NonEmptyList[GBQSchema]] =
-    columns.traverse(mkColumn(_)).toEither leftMap { errs =>
-      s"Some column types are not supported: ${mkErrorString(errs)}"
-    }
-
-  private def mkColumn(c: Column[ColumnType.Scalar]): ValidatedNel[ColumnType.Scalar, GBQSchema] =
-    tblColumnToGbq(c.tpe).map(s => GBQSchema(s, c.name))
-
-  private def tblColumnToGbq(ct: ColumnType.Scalar): ValidatedNel[ColumnType.Scalar, String] =
-    ct match {
-        case ColumnType.String => "STRING".validNel
-        case ColumnType.Boolean => "BOOL".validNel
-        case ColumnType.Number => "NUMERIC".validNel
-        case ColumnType.LocalDate => "DATE".validNel
-        case ColumnType.LocalDateTime => "DATETIME".validNel
-        case ColumnType.LocalTime => "TIME".validNel
-        case ColumnType.OffsetTime => "STRING".validNel
-        case ColumnType.OffsetDateTime => "STRING".validNel
-        case ColumnType.OffsetDate => "STRING".validNel
-        case i @ ColumnType.Interval => i.invalidNel
-        case ColumnType.Null => "INTEGER1".validNel
-      }
-
-  private def mkDataset(client: Client[F], accessToken: String, config: GBQConfig): F[Either[InitializationError[Json], Unit]] = {
-    implicit def jobConfigEntityEncoder: EntityEncoder[F, GBQDatasetConfig] =
-      jsonEncoderOf[F, GBQDatasetConfig]
-
-    val dCfg = GBQDatasetConfig(config.authCfg.projectId, config.datasetId)
-    val bearerToken = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken))
-    val project = URLEncoder.encode(config.authCfg.projectId, StandardCharsets.UTF_8.toString)
-    val datasetUrlString = s"https://bigquery.googleapis.com/bigquery/v2/projects/${project}/datasets"
-    val uri = StringToUri.get(datasetUrlString)
-
-    uri.fold(_.asLeft[Unit].pure[F], uri => {
-
-      val datasetReq = Request[F](Method.POST, uri)
-        .withHeaders(bearerToken)
-        .withContentType(`Content-Type`(MediaType.application.json))
-        .withEntity(dCfg)
-
-        client.run(datasetReq).use { resp =>
-          resp.status match {
-            case Status.Ok => ().asRight[InitializationError[Json]].pure[F]
-            case Status.Conflict =>
-              DestinationError.invalidConfiguration(
-                (destinationType,
-                jString(s"Reason: ${resp.status.reason}"),
-                ZNEList(resp.status.reason))).asLeft[Unit].pure[F]
-            case status =>
-              DestinationError.malformedConfiguration(
-                (destinationType, jString(s"Reason: ${status.reason}"),
-                sanitizedConfig.toString)).asLeft[Unit].pure[F]
-          }
-        }
-    })
-  }
-
-  private def mkGbqJob(client: Client[F], accessToken: String, jCfg: GBQJobConfig): F[Either[InitializationError[Json], Uri]] = {
-    implicit def jobConfigEntityEncoder: EntityEncoder[F, GBQJobConfig] = jsonEncoderOf[F, GBQJobConfig]
-
-    val authToken = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken))
-    val project = URLEncoder.encode(jCfg.destinationTable.project, StandardCharsets.UTF_8.toString)
-    val jobUrlString = s"https://bigquery.googleapis.com/upload/bigquery/v2/projects/${project}/jobs?uploadType=resumable"
-    val uri = StringToUri.get(jobUrlString)
-
-    uri.fold(_.asLeft[Uri].pure[F], uri => {
-      val jobReq = Request[F](Method.POST,uri)
-          .withHeaders(authToken)
-          .withContentType(`Content-Type`(MediaType.application.json))
-          .withEntity(jCfg)
-
-      client.run(jobReq).use { resp =>
-        resp.status match {
-          case Status.Ok => resp.headers match {
-            case Location(loc) => loc.uri.asRight[InitializationError[Json]].pure[F]
-          }
-          case _ =>  DestinationError.malformedConfiguration(
-            (destinationType, jString("Reason: " + resp.status.reason),
-            sanitizedConfig.toString)).asLeft[Uri].pure[F]
-        }
-      }
-    })
-  }
-
-  private def upload(client: Client[F], bytes: Stream[F, Byte], uploadLocation: Uri): Stream[F, Unit] = {
-    val destReq = Request[F](Method.PUT, uploadLocation)
-        .putHeaders(Header("Host", "www.googleapis.com"))
-        .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
-        .withEntity(bytes)
-    val doUpload = client.run(destReq).use { resp =>
-      resp.status match {
-        case Status.Ok => ().pure[F]
-        case _ => ApplicativeError[F, Throwable].raiseError[Unit](
-            new RuntimeException(s"Upload failed: ${resp.status.reason}" ))
-      }
-    }
-    Stream.eval(doUpload)
-  }
+  def maxFileSize = config.maxFileSize getOrElse GBQDestination.DefaultMaxFileSize
 }
 
 object GBQDestination {
+  val DefaultMaxFileSize = 1024L * 1024L * 1024L
+
   def apply[F[_]: Concurrent: ContextShift: MonadResourceErr: ConcurrentEffect](config: Json)
       : Resource[F, Either[InitializationError[Json], Destination[F]]] = {
-
-    val sanitizedConfig: Json = GBQDestinationModule.sanitizeDestinationConfig(config)
 
     val configOrError = config.as[GBQConfig].toEither.leftMap {
       case (err, _) =>
@@ -251,16 +81,15 @@ object GBQDestination {
     val init = for {
       cfg <- EitherT(Resource.pure[F, Either[InitializationError[Json], GBQConfig]](configOrError))
       client <- EitherT(AsyncHttpClientBuilder[F].map(_.asRight[InitializationError[Json]]))
-      _ <- EitherT(Resource.liftF(isLive(client, cfg, sanitizedConfig)))
-    } yield new GBQDestination[F](client, cfg, sanitizedConfig): Destination[F]
+      _ <- EitherT(Resource.liftF(isLive(client, cfg)))
+    } yield new GBQDestination[F](client, cfg): Destination[F]
 
     init.value
   }
 
   private def isLive[F[_]: Concurrent: ContextShift](
       client: Client[F],
-      config: GBQConfig,
-      sanitizedConfig: Json)
+      config: GBQConfig)
       : F[Either[InitializationError[Json], Unit]] = {
     val project = URLEncoder.encode(config.authCfg.projectId, StandardCharsets.UTF_8.toString)
     val datasetsUrlString = s"https://www.googleapis.com/bigquery/v2/projects/${project}/datasets"
@@ -276,7 +105,7 @@ object GBQDestination {
             case _ => DestinationError.malformedConfiguration((
               GBQDestinationModule.destinationType,
               jString(resp.status.reason),
-              sanitizedConfig.toString)).asLeft[Unit].pure[F]
+              config.sanitizedJson.toString)).asLeft[Unit].pure[F]
           }
         }
       })

--- a/core/src/main/scala/quasar/destination/gbq/GBQDestinationModule.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQDestinationModule.scala
@@ -21,7 +21,7 @@ import quasar.api.destination.DestinationError.InitializationError
 import quasar.connector.destination.{Destination, DestinationModule, PushmiPullyu}
 import quasar.connector.MonadResourceErr
 
-import argonaut._, Argonaut._
+import argonaut._
 
 import cats.effect.{
   ConcurrentEffect,
@@ -43,7 +43,7 @@ object GBQDestinationModule extends DestinationModule with Logging {
 
   def sanitizeDestinationConfig(config: Json) = {
     config.as[GBQConfig].toOption match {
-      case Some(c) => Json("authCfg" := GBQConfig.Redacted, "datasetId" := c.datasetId)
+      case Some(c) => c.sanitizedJson
       case _ => Json.jEmptyObject
     }
   }

--- a/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
@@ -128,7 +128,7 @@ final class GBQFlow[F[_]: Concurrent](
     val query =
       s"DELETE FROM ${config.authCfg.projectId}.${config.datasetId}.$name $where"
 
-    val qConfig = QueryJobConfig(query, 6 * 3600 * 1000)
+    val qConfig = QueryJobConfig(query, 6L * 3600L * 1000L)
 
     filter(qConfig)
   }

--- a/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
@@ -1,0 +1,314 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.gbq
+
+import slamdata.Predef._
+
+import quasar.api.{Column, ColumnType}
+import quasar.api.destination.DestinationError
+import quasar.api.destination.DestinationError.InitializationError
+import quasar.api.resource.ResourceName
+import quasar.connector.{MonadResourceErr, ResourceError, IdBatch}
+import quasar.connector.destination.WriteMode
+
+import argonaut._, Argonaut._
+
+import cats.ApplicativeError
+import cats.data.{ValidatedNel, NonEmptyList}
+import cats.effect.{Concurrent, Resource, Sync}
+import cats.effect.concurrent.Ref
+import cats.implicits._
+
+import fs2.{Pipe, Stream}
+import cats.effect._
+
+import org.http4s.{
+  AuthScheme,
+  Credentials,
+  EntityEncoder,
+  MediaType,
+  Method,
+  Request,
+  Status,
+  Uri
+}
+import org.http4s.argonaut.jsonEncoderOf
+import org.http4s.client._
+import org.http4s.Header
+import org.http4s.headers.{Authorization, `Content-Type`, Location}
+
+import scalaz.{NonEmptyList => ZNEList}
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import com.google.auth.oauth2.AccessToken
+
+final class GBQFlow[F[_]: Concurrent](
+    name: String,
+    schema: NonEmptyList[GBQSchema],
+    idColumn: Option[Column[_]],
+    config: GBQConfig,
+    client: Client[F],
+    refMode: Ref[F, WriteMode])
+    extends Flow[F] {
+
+  private def credsF =
+    tokenF map { token =>
+      Authorization(Credentials.Token(AuthScheme.Bearer, token.getTokenValue))
+    }
+
+  private val project =
+    URLEncoder.encode(config.authCfg.projectId, StandardCharsets.UTF_8.toString)
+
+  private val uriRoot =
+    s"https://bigquery.googleapis.com/bigquery/v2/projects/${project}"
+
+  private def tokenF: F[AccessToken] =
+    GBQAccessToken.token(config.serviceAccountAuthBytes)
+
+  def ingest: Pipe[F, Byte, Unit] = { (bytes: Stream[F, Byte]) =>
+    for {
+      eitherloc <- Stream.eval {
+        for {
+          mode <- refMode.get
+          jobConfig = formGBQJobConfig(schema, config, name, mode)
+          _ <- mkDataset.whenA(mode === WriteMode.Replace)
+          eloc <- mkGbqJob(jobConfig)
+        } yield eloc
+      }
+      _ <- eitherloc match {
+        case Right(locationUri) => upload(bytes, locationUri)
+        case Left(e) => Stream.raiseError[F](new RuntimeException(s"No Location URL returned from job: $e"))
+      }
+      _ <- Stream.eval(refMode.set(WriteMode.Append))
+    } yield ()
+  }
+
+  def delete(ids: IdBatch): Stream[F, Unit] = idColumn traverse_ { (col: Column[_]) =>
+    val strs: Array[String] = ids match {
+      case IdBatch.Strings(values, _) => values.map(x => "\"" + x + "\"")
+      case IdBatch.Longs(values, _) => values.map(_.toString)
+      case IdBatch.Doubles(values, _) => values.map(_.toString)
+      case IdBatch.BigDecimals(values, _) => values.map(_.toString)
+    }
+
+    def mkIn(strs: Array[String]): String = {
+      if (strs.isEmpty) ""
+      else s"${col.name} IN (${strs.mkString(", ")})"
+    }
+
+    def group(ix: Int, accum: List[String]): String = {
+      val nextIx = ix + 64
+      val taken = strs.slice(ix, nextIx)
+      val in = mkIn(taken)
+      val nextAccum = in :: accum
+      if (nextIx > ids.size + 1)
+        nextAccum.mkString(" OR ")
+      else
+        group(nextIx, nextAccum)
+    }
+
+    val groupped = group(0, List())
+
+    val where = if (groupped.isEmpty) "" else s"WHERE $groupped"
+
+    val query =
+      s"DELETE FROM ${config.authCfg.projectId}.${config.datasetId}.$name $where"
+
+    val qConfig = QueryJobConfig(query, 6 * 3600 * 1000)
+
+    filter(qConfig)
+  }
+
+  private def filter(q: QueryJobConfig): Stream[F, Unit] = {
+    implicit def entityEncoder: EntityEncoder[F, QueryJobConfig] =
+      jsonEncoderOf[F, QueryJobConfig]
+
+    val uri = StringToUri.get(s"$uriRoot/queries")
+
+    uri match {
+      case Left(_) => Stream.raiseError[F](new RuntimeException(s"Incorrect url constructed: $uriRoot/queries"))
+      case Right(uri) =>
+        val reqF = credsF map { creds =>
+          Request[F](Method.POST, uri)
+            .withHeaders(creds)
+            .withContentType(`Content-Type`(MediaType.application.json))
+            .withEntity(q)
+        }
+
+        Stream.eval(reqF).flatMap(client.stream) flatMap { resp => resp.status match {
+          case Status.Ok =>
+            ().pure[Stream[F, *]]
+          case x =>
+            Stream.raiseError[F](new RuntimeException("An error occured during existing ids filtering"))
+        }}
+    }
+  }
+
+  private def formGBQJobConfig(
+      schema: NonEmptyList[GBQSchema],
+      config: GBQConfig,
+      tableId: String,
+      mode: WriteMode)
+      : GBQJobConfig = {
+    val disposition = mode match {
+      case WriteMode.Replace => WriteDisposition("WRITE_TRUNCATE")
+      case WriteMode.Append => WriteDisposition("WRITE_APPEND")
+    }
+
+    GBQJobConfig(
+      "CSV",
+      0,
+      true,
+      schema.toList,
+      "DAY",
+      disposition,
+      GBQDestinationTable(config.authCfg.projectId, config.datasetId, tableId),
+      21600000, // 6hrs load job limit
+      "LOAD")
+  }
+
+
+  private def mkDataset: F[Either[InitializationError[Json], Unit]] = {
+
+    implicit def jobConfigEntityEncoder: EntityEncoder[F, GBQDatasetConfig] =
+      jsonEncoderOf[F, GBQDatasetConfig]
+
+    val dCfg = GBQDatasetConfig(config.authCfg.projectId, config.datasetId)
+
+    val uri = StringToUri.get(s"$uriRoot/datasets")
+
+    uri.fold(_.asLeft[Unit].pure[F], uri => {
+
+      val datasetReqF = credsF map { creds =>
+        Request[F](Method.POST, uri)
+          .withHeaders(creds)
+          .withContentType(`Content-Type`(MediaType.application.json))
+          .withEntity(dCfg)
+        }
+
+        Resource.liftF(datasetReqF).flatMap(client.run).use { resp =>
+          resp.status match {
+            case Status.Ok => ().asRight[InitializationError[Json]].pure[F]
+            case Status.Conflict =>
+              DestinationError.invalidConfiguration(
+                (GBQDestinationModule.destinationType,
+                jString(s"Reason: ${resp.status.reason}"),
+                ZNEList(resp.status.reason))).asLeft[Unit].pure[F]
+            case status =>
+              DestinationError.malformedConfiguration(
+                (GBQDestinationModule.destinationType, jString(s"Reason: ${status.reason}"),
+                config.sanitizedJson.toString)).asLeft[Unit].pure[F]
+          }
+        }
+    })
+  }
+
+  private def mkGbqJob(jCfg: GBQJobConfig): F[Either[InitializationError[Json], Uri]] = {
+    implicit def jobConfigEntityEncoder: EntityEncoder[F, GBQJobConfig] = jsonEncoderOf[F, GBQJobConfig]
+
+    val project =
+      URLEncoder.encode(jCfg.destinationTable.project, StandardCharsets.UTF_8.toString)
+    val jobUrlString =
+      s"https://bigquery.googleapis.com/upload/bigquery/v2/projects/${project}/jobs?uploadType=resumable"
+    val uri =
+      StringToUri.get(jobUrlString)
+
+    uri.fold(_.asLeft[Uri].pure[F], uri => {
+      val jobReq = credsF map { creds =>
+        Request[F](Method.POST,uri)
+          .withHeaders(creds)
+          .withContentType(`Content-Type`(MediaType.application.json))
+          .withEntity(jCfg)
+      }
+
+      Resource.liftF(jobReq).flatMap(client.run).use { resp =>
+        resp.status match {
+          case Status.Ok => resp.headers match {
+            case Location(loc) => loc.uri.asRight[InitializationError[Json]].pure[F]
+          }
+          case _ =>  DestinationError.malformedConfiguration(
+            (GBQDestinationModule.destinationType, jString("Reason: " + resp.status.reason),
+            config.sanitizedJson.toString)).asLeft[Uri].pure[F]
+        }
+      }
+    })
+  }
+
+  private def upload(bytes: Stream[F, Byte], uploadLocation: Uri): Stream[F, Unit] = {
+    val destReq = Request[F](Method.PUT, uploadLocation)
+        .putHeaders(Header("Host", "www.googleapis.com"))
+        .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
+        .withEntity(bytes)
+    client.stream(destReq) evalMap { resp =>
+      resp.status match {
+        case Status.Ok => ().pure[F]
+        case _ => ApplicativeError[F, Throwable].raiseError[Unit](
+            new RuntimeException(s"Upload failed: ${resp.status.reason}" ))
+      }
+    }
+  }
+}
+
+object GBQFlow {
+  def apply[F[_]: Concurrent: MonadResourceErr](
+      config: GBQConfig,
+      client: Client[F],
+      args: GBQSinks.Args)
+      : F[Flow[F]] = {
+    val tableNameF = args.path.uncons match {
+      case Some((ResourceName(name), _)) => name.pure[F]
+      case _ => MonadResourceErr[F].raiseError[String](ResourceError.notAResource(args.path))
+    }
+    for {
+      name <- tableNameF
+      ref <- Ref.of[F, WriteMode](args.writeMode)
+      columns <- ensureValidColumns[F](args.columns)
+    } yield new GBQFlow(name, columns, args.idColumn, config, client, ref)
+  }
+
+  private def ensureValidColumns[F[_]: Sync](
+      columns: NonEmptyList[Column[ColumnType.Scalar]])
+      : F[NonEmptyList[GBQSchema]] =
+    columns.traverse(mkColumn(_)).toEither match {
+      case Right(a) => a.pure[F]
+      case Left(errs) => Sync[F].raiseError { new RuntimeException {
+        s"Some column types are not supported: ${mkErrorString(errs)}"
+      }}
+    }
+  private def mkErrorString(errs: NonEmptyList[ColumnType.Scalar]): String =
+    errs
+      .map(err => s"Column of type ${err.show} is not supported by Gooble Big Query")
+      .intercalate(", ")
+
+  private def mkColumn(c: Column[ColumnType.Scalar]): ValidatedNel[ColumnType.Scalar, GBQSchema] =
+    tblColumnToGbq(c.tpe).map(s => GBQSchema(s, c.name))
+
+  private def tblColumnToGbq(ct: ColumnType.Scalar): ValidatedNel[ColumnType.Scalar, String] =
+    ct match {
+        case ColumnType.String => "STRING".validNel
+        case ColumnType.Boolean => "BOOL".validNel
+        case ColumnType.Number => "NUMERIC".validNel
+        case ColumnType.LocalDate => "DATE".validNel
+        case ColumnType.LocalDateTime => "DATETIME".validNel
+        case ColumnType.LocalTime => "TIME".validNel
+        case ColumnType.OffsetTime => "STRING".validNel
+        case ColumnType.OffsetDateTime => "STRING".validNel
+        case ColumnType.OffsetDate => "STRING".validNel
+        case i @ ColumnType.Interval => i.invalidNel
+        case ColumnType.Null => "INTEGER1".validNel
+      }
+}

--- a/core/src/main/scala/quasar/destination/gbq/GBQSinks.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQSinks.scala
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2020 Precog Data
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package quasar.destination.gbq
+
+import slamdata.Predef._
+
+import quasar.api.{Column, ColumnType}
+import quasar.api.push.OffsetKey
+import quasar.api.resource._
+import quasar.connector._
+import quasar.connector.destination.{ResultSink, WriteMode}, ResultSink.{UpsertSink, AppendSink}
+import quasar.connector.render.RenderConfig
+
+import cats.data._
+import cats.effect.Concurrent
+import cats.implicits._
+
+import fs2.{Stream, Pipe, Chunk}
+
+import skolems.∀
+
+import GBQSinks._
+
+trait GBQSinks[F[_]] {
+  type Consume[E[_], A] =
+    Pipe[F, E[OffsetKey.Actual[A]], OffsetKey.Actual[A]]
+
+  def flowF(args: Args): F[Flow[F]]
+
+  def maxFileSize: Long
+
+  def render: RenderConfig[Byte] =
+    RenderConfig.Csv(includeHeader = false, numericScale = 9.some)
+
+  def flowSinks(implicit F: Concurrent[F]): NonEmptyList[ResultSink[F, ColumnType.Scalar]] =
+    NonEmptyList.of(ResultSink.create(create), ResultSink.upsert(upsert), ResultSink.append(append))
+
+  def create(path: ResourcePath, cols: NonEmptyList[FlowColumn])(implicit F: Concurrent[F])
+      : (RenderConfig[Byte], Pipe[F, Byte, Unit]) = {
+    val args = Args.ofCreate(path, cols)
+    (render, in => for {
+      flow <- Stream.eval(flowF(args))
+      _ <- in
+        .through(Event.fromByteStream[F](maxFileSize))
+        .through(upsertPipe0[Unit](flow))
+    } yield ())
+  }
+
+  def upsert(upsertArgs: UpsertSink.Args[ColumnType.Scalar])(implicit F: Concurrent[F])
+      : (RenderConfig[Byte], ∀[Consume[DataEvent[Byte, *], *]]) = {
+    val args = Args.ofUpsert(upsertArgs)
+    val consume = ∀[Consume[DataEvent[Byte, *], *]](upsertPipe(args))
+    (render, consume)
+  }
+
+  def append(appendArgs: AppendSink.Args[ColumnType.Scalar])(implicit F: Concurrent[F])
+      : (RenderConfig[Byte], ∀[Consume[AppendEvent[Byte, *], *]]) = {
+    val args = Args.ofAppend(appendArgs)
+    val consume = ∀[Consume[AppendEvent[Byte, *], *]](upsertPipe(args))
+    (render, consume)
+  }
+
+  private def upsertPipe[A](args: Args)(implicit F: Concurrent[F])
+      : Pipe[F, DataEvent[Byte, OffsetKey.Actual[A]], OffsetKey.Actual[A]] = { events =>
+    for {
+      flow <- Stream.eval(flowF(args))
+      offset <- events
+        .through(Event.fromDataEvent[F, OffsetKey.Actual[A]](maxFileSize))
+        .through(upsertPipe0[OffsetKey.Actual[A]](flow))
+    } yield offset
+  }
+
+  private def upsertPipe0[A](flow: Flow[F])
+      : Pipe[F, Event[F, A], A] = { events =>
+    def handleEvent: Pipe[F, Event[F, A], Option[A]] = _ flatMap {
+      case Event.Create(stream) =>
+        flow.ingest(stream).mapChunks(_ => Chunk(none[A]))
+      case Event.Delete(ids) =>
+        flow.delete(ids).mapChunks(_ => Chunk(none[A]))
+      case Event.Commit(offset) =>
+        Stream.emit(offset.some)
+    }
+    events.through(handleEvent).unNone
+  }
+}
+
+object GBQSinks {
+  private type FlowColumn = Column[ColumnType.Scalar]
+
+  sealed trait Args {
+    def path: ResourcePath
+    def columns: NonEmptyList[FlowColumn]
+    def writeMode: WriteMode
+    def idColumn: Option[Column[_]]
+  }
+
+  object Args {
+    def ofCreate(p: ResourcePath, cs: NonEmptyList[FlowColumn]): Args = new Args {
+      def path = p
+      def columns = cs
+      def writeMode = WriteMode.Replace
+      def idColumn = None
+    }
+
+    def ofUpsert(args: UpsertSink.Args[ColumnType.Scalar]): Args = new Args {
+      def path = args.path
+      def columns = args.columns
+      def writeMode = args.writeMode
+      def idColumn = args.idColumn.some
+    }
+
+    def ofAppend(args: AppendSink.Args[ColumnType.Scalar]): Args = new Args {
+      def path = args.path
+      def columns = args.columns
+      def writeMode = args.writeMode
+      def idColumn = args.pushColumns.primary
+    }
+  }
+}

--- a/core/src/main/scala/quasar/destination/gbq/QueryJobConfig.scala
+++ b/core/src/main/scala/quasar/destination/gbq/QueryJobConfig.scala
@@ -16,22 +16,21 @@
 
 package quasar.destination.gbq
 
-import scala.Predef.String
+import slamdata.Predef._
 
 import argonaut._, Argonaut._
 
-final case class GBQDatasetConfig(projectId: String, datasetId: String)
+final case class QueryJobConfig(
+  query: String,
+  timeoutMs: Long)
 
-object GBQDatasetConfig {
-  implicit val codecJson: CodecJson[GBQDatasetConfig] =
-    CodecJson(
-      (g: GBQDatasetConfig) => Json.obj(
-        "datasetReference" := Json.obj(
-          "projectId" := g.projectId,
-          "datasetId" := g.datasetId
-        )),
-      c => for {
-        projectId <- (c --\ "datasetReference" --\ "projectId").as[String]
-        datasetId <- (c --\ "datasetReference" --\ "datasetId").as[String]
-      } yield GBQDatasetConfig(projectId, datasetId))
+object QueryJobConfig {
+  implicit val encode: EncodeJson[QueryJobConfig] = EncodeJson { (jc: QueryJobConfig) =>
+    ("query" := jc.query) ->:
+    ("timeoutMs" := jc.timeoutMs) ->:
+    ("useLegacySql" := false) ->:
+    ("useQueryCache" := false) ->:
+    jEmptyObject
+  }
 }
+

--- a/core/src/test/scala/quasar/destination/gbq/GBQConfigSpec.scala
+++ b/core/src/test/scala/quasar/destination/gbq/GBQConfigSpec.scala
@@ -16,11 +16,11 @@
 
 package quasar.destination.gbq
 
+import slamdata.Predef._
+
 import argonaut.{Argonaut, DecodeJson, Json}, Argonaut._
 
 import org.specs2.mutable.Specification
-
-import scala.StringContext
 
 import java.net.URI
 
@@ -65,7 +65,8 @@ object GBQConfigSpec extends Specification {
       privateKeyId = PRIVATE_KEY_ID,
       clientEmail = CLIENT_EMAIL,
       accountType = ACCOUNT_TYPE),
-    datasetId = DATASET)
+    datasetId = DATASET,
+    maxFileSize = None)
 
   "decode json config to GBQConfig" >> {
     decode(jsonGbqCfg).toOption must beSome(testGbqCfg)
@@ -76,7 +77,7 @@ object GBQConfigSpec extends Specification {
   }
 
   "ensure GBQConfig will be readacted" >> {
-    GBQDestinationModule.sanitizeDestinationConfig(jsonGbqCfg) must_=== 
+    GBQDestinationModule.sanitizeDestinationConfig(jsonGbqCfg) must_===
       Json.obj("authCfg" := jString("<REDACTED>"), "datasetId" := jString(DATASET))
   }
 }

--- a/core/src/test/scala/quasar/destination/gbq/GBQDestinationModuleSpec.scala
+++ b/core/src/test/scala/quasar/destination/gbq/GBQDestinationModuleSpec.scala
@@ -16,6 +16,7 @@
 
 package quasar.destination.gbq
 
+import slamdata.Predef._
 import scala.Predef.String
 
 import quasar.EffectfulQSpec

--- a/core/src/test/scala/quasar/destination/gbq/GBQDestinationSpec.scala
+++ b/core/src/test/scala/quasar/destination/gbq/GBQDestinationSpec.scala
@@ -273,6 +273,8 @@ object GBQDestinationSpec extends EffectfulQSpec[IO] {
         DataEvent.Commit(OffsetKey.Actual.string("commit0")))
 
       val data1: Stream[IO, DataEvent[Byte, OffsetKey.Actual[String]]] = Stream(
+        // Checking that empty delte doesn't drop the table
+        DataEvent.Delete(IdBatch.Strings(Array(), 0)),
         DataEvent.Create(Chunk.array("d,4\r\n".getBytes)),
         DataEvent.Commit(OffsetKey.Actual.string("commit1")),
         DataEvent.Create(Chunk.array("e,5\r\n".getBytes)),

--- a/core/src/test/scala/quasar/destination/gbq/GBQDestinationSpec.scala
+++ b/core/src/test/scala/quasar/destination/gbq/GBQDestinationSpec.scala
@@ -16,13 +16,12 @@
 
 package quasar.destination.gbq
 
-import slamdata.Predef.RuntimeException
-
-import scala.Predef.String
+import slamdata.Predef._
 
 import quasar.api.{Column, ColumnType}
-import quasar.api.destination.DestinationError.InitializationError
-import quasar.connector.destination.{Destination, PushmiPullyu, ResultSink}
+import quasar.api.push.{OffsetKey, PushColumns}
+import quasar.connector._
+import quasar.connector.destination.{Destination, PushmiPullyu, ResultSink, WriteMode}, ResultSink.{AppendSink, UpsertSink}
 import quasar.api.resource.{ResourceName, ResourcePath}
 import quasar.connector.ResourceError
 import quasar.contrib.scalaz.MonadError_
@@ -31,39 +30,42 @@ import quasar.EffectfulQSpec
 import argonaut._, Argonaut._
 
 import cats.data.NonEmptyList
-import cats.effect.{Blocker, IO, Timer}
+import cats.effect.{Blocker, IO, Timer, Resource}
 
-import fs2.{Pipe, Stream, text}
+import fs2.{Pipe, Stream, Chunk}
 
-import org.http4s.client.Client
+import org.http4s.argonaut.jsonOf
+import org.http4s.client._
 import org.http4s.{
+  Header,
   AuthScheme,
   Credentials,
   Method,
   Request,
   Status,
-  Uri
+  Uri,
+  EntityDecoder
 }
 import org.http4s.headers.Authorization
-import org.http4s.client._
 
-
-import scala.{Byte, Either, StringContext, Unit}
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.util.Right
 import scala.util.Left
 
-import scalaz.{-\/,\/-}
+import scalaz.-\/
 
 import java.nio.file.{Files, Paths}
 import java.nio.charset.StandardCharsets.UTF_8
 import java.util.concurrent.Executors
 import java.util.UUID
 
+import org.specs2.matcher.MatchResult
+
 import shims._
 import shapeless.PolyDefns.identity
+import skolems.∀
 
 object GBQDestinationSpec extends EffectfulQSpec[IO] {
   sequential
@@ -75,166 +77,364 @@ object GBQDestinationSpec extends EffectfulQSpec[IO] {
   val TEST_PROJECT = "precog-ci-275718"
   val AUTH_FILE = "precog-ci-275718-e913743ebfeb.json"
 
-  val testDataset = "dataset_" + UUID.randomUUID.toString.replace("-", "_").toString
-  val tableName = "table_" + UUID.randomUUID.toString.replace("-", "_").toString
-
-  val authCfgPath = Paths.get(getClass.getClassLoader.getResource(AUTH_FILE).toURI)
-  val authCfgString = new String(Files.readAllBytes(authCfgPath), UTF_8)
-  val authCfgJson: Json = Parse.parse(authCfgString) match {
-    case Left(value) => Json.obj("malformed" := true)
-    case Right(value) => value
+  val configAndTableF: IO[(GBQConfig, String)] = for {
+    dataset <- IO("dataset_" + UUID.randomUUID.toString.replace("-", "_").toString)
+    tableName <- IO("table_" + UUID.randomUUID.toString.replace("-", "_").toString)
+  } yield {
+    val authCfgPath = Paths.get(getClass.getClassLoader.getResource(AUTH_FILE).toURI)
+    val authCfgString = new String(Files.readAllBytes(authCfgPath), UTF_8)
+    val authCfgJson: Json = Parse.parse(authCfgString) match {
+      case Left(value) => Json.obj("malformed" := true)
+      case Right(value) => value
+    }
+    val config = GBQConfig(authCfgJson.as[ServiceAccountConfig].toOption.get, dataset, None)
+    (config, tableName)
   }
 
-  val gbqConfig = GBQConfig(authCfgJson.as[ServiceAccountConfig].toOption.get, testDataset)
-  val gbqCfg = gbqConfig.asJson
   val blockingPool = Executors.newFixedThreadPool(5)
   val blocker = Blocker.liftExecutorService(blockingPool)
   val httpClient: Client[IO] = JavaNetClientBuilder[IO](blocker).create
 
+  val UriRoot = s"https://bigquery.googleapis.com/bigquery/v2/projects/${TEST_PROJECT}/datasets"
+
+  val waitABit = Timer[IO].sleep(5.seconds)
+
+  final case class Row(tag: String, value: Int)
+
+  object Row {
+    implicit def decode: DecodeJson[Row] = DecodeJson { c =>
+      for {
+        tag <- c.downField("f").downN(0).downField("v").as[String]
+        value <- c.downField("f").downN(1).downField("v").as[Int]
+      } yield Row(tag, value)
+    }
+    implicit def entityDecoder: EntityDecoder[IO, Row] =
+      jsonOf
+  }
+
+  final case class Rows(values: List[Row])
+  object Rows {
+    implicit def decode: DecodeJson[Rows] = DecodeJson { c =>
+      c.downField("rows").as[List[Row]].map(Rows(_))
+    }
+    implicit def entityDecoder: EntityDecoder[IO, Rows] =
+      jsonOf
+
+  }
+
+  implicit def encoder: EntityDecoder[IO, Json] =
+    jsonOf
+
   "csv link" should {
     "reject empty paths with NotAResource" >>* {
       val path = ResourcePath.root()
-      val req = csv(gbqCfg) { consume =>
-        consume(path, NonEmptyList.one(Column("a", ColumnType.Boolean)))
-          .apply(Stream.empty)
-          .compile.drain
-      }
-      MRE.attempt(req).map(_ must beLike {
+      for {
+        (conf, _) <- configAndTableF
+        resp <- MRE.attempt(csv(conf.asJson).use({ consume =>
+          consume(path, NonEmptyList.one(Column("a", ColumnType.Boolean)))
+            .apply(Stream.empty)
+            .compile.drain
+        }))
+      } yield resp must beLike {
         case -\/(ResourceError.NotAResource(p2)) => p2 must_=== path
-      })
+      }
     }
   }
 
   "bigquery upload" should {
+    "create sink successfully uploads table" >> {
+      val data =
+        Stream(
+          Chunk.array("col1,false\r\n".getBytes),
+          Chunk.array("stuff,true\r\n".getBytes))
+        .flatMap(Stream.chunk(_))
 
-    "successfully upload table" >>* {
-      val data = Stream("col1,col2\r\nstuff,true\r\n").through(text.utf8Encode)
-      val path = ResourcePath.root() / ResourceName(tableName) / ResourceName("bar.csv")
-      val req =  csv(gbqCfg) { consume =>
-        data
-          .through(consume(
-            path,
-            NonEmptyList.of(Column("a", ColumnType.String), Column("b", ColumnType.Boolean))))
-          .compile.drain
+      def check(f: GBQConfig => GBQConfig): IO[MatchResult[Boolean]] = {
+        for {
+          (config0, tableName) <- configAndTableF
+          config = f(config0)
+          path = ResourcePath.root() / ResourceName(tableName) / ResourceName("bar.csv")
+          req = csv(config.asJson).use { consume =>
+            data
+              .through(consume(
+                path,
+                NonEmptyList.of(Column("a", ColumnType.String), Column("b", ColumnType.Boolean))))
+              .compile.drain
+          }
+          consumedR <- req.attempt
+          _ <- waitABit
+
+          accessToken <- GBQAccessToken.token[IO](config.serviceAccountAuthBytes)
+          auth = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken.getTokenValue))
+
+          datasetReq = Request[IO](
+            method = Method.GET,
+            uri = Uri.fromString(UriRoot)
+              .getOrElse(Uri()))
+              .withHeaders(auth)
+          datasetResp <- httpClient.run(datasetReq) use {
+            case Status.Successful(r) => r.as[String]
+            case r => IO.raiseError(new Throwable("Dataset request failed"))
+          }
+          _ <- waitABit
+
+          tableReq = Request[IO](
+            method = Method.GET,
+            uri = Uri.fromString(s"$UriRoot/${config.datasetId}/tables")
+              .getOrElse(Uri()))
+              .withHeaders(auth)
+          tableResp <- httpClient.run(tableReq).use {
+            case Status.Successful(r) => r.as[String]
+            case r => IO.raiseError(new Throwable("Table request failed"))
+          }
+          _ <- waitABit
+
+
+          contentResponse <- getContent[String](config.datasetId, tableName, auth)
+          _ <- waitABit
+
+          deleted <- deleteDataset(config.datasetId, auth)
+
+        } yield {
+          deleted must beTrue
+          consumedR must beRight(())
+          datasetResp.contains(config.datasetId) must beTrue
+          tableResp.contains(tableName) must beTrue
+          contentResponse.contains("stuff") must beTrue
+          contentResponse.contains("true") must beTrue
+          contentResponse.contains("false") must beTrue
+          contentResponse.contains("col1") must beTrue
+        }
       }
-      Timer[IO].sleep(5.seconds).flatMap { _ =>
-        MRE.attempt(req).map(_ must beLike {
-          case \/-(value) => value must_===(())
-        })
-      }
+      "default (1GB) max file size" >>* check(identity)
+      "0 max file size (one file per row)" >>* check(_.copy(maxFileSize = Some(0L)))
     }
+    "append sink upload tables and append data" >>* {
+      val data0: Stream[IO, AppendEvent[Byte, OffsetKey.Actual[String]]] = Stream(
+        DataEvent.Create(Chunk.array("a,1\r\n".getBytes)),
+        DataEvent.Create(Chunk.array("b,2\r\nc,3\r\n".getBytes)),
+        DataEvent.Commit(OffsetKey.Actual.string("commit0")))
 
-    "successfully check dataset was created" >>* {
-      for {
-        accessToken <- GBQAccessToken.token[IO](gbqConfig.serviceAccountAuthBytes)
-        auth = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken.getTokenValue))
-        req = Request[IO](
-          method = Method.GET,
-          uri = Uri.fromString(s"https://bigquery.googleapis.com/bigquery/v2/projects/${TEST_PROJECT}/datasets")
-            .getOrElse(Uri()))
-            .withHeaders(auth)
-        resp <- Timer[IO].sleep(5.seconds).flatMap { _ =>
-          httpClient.run(req).use {
-            case Status.Successful(r) => r.attemptAs[String].leftMap(_.message).value
-            case r => r.as[String].map(b => Left(s"Request ${req} failed with status ${r.status.code} and body ${b}"))
-        }}
-        body = resp.fold(identity, identity)
-        result <- IO {
-           body.contains(testDataset) must beTrue
-        }
-      } yield result
-    }
+      val data1: Stream[IO, AppendEvent[Byte, OffsetKey.Actual[String]]] = Stream(
+        DataEvent.Create(Chunk.array("d,4\r\n".getBytes)),
+        DataEvent.Commit(OffsetKey.Actual.string("commit1")),
+        DataEvent.Create(Chunk.array("e,5\r\n".getBytes)),
+        DataEvent.Commit(OffsetKey.Actual.string("commit2")))
 
-    "successfully check uploaded table exists" >>* {
-      for {
-        accessToken <- GBQAccessToken.token[IO](gbqConfig.serviceAccountAuthBytes)
-        auth = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken.getTokenValue))
-        req = Request[IO](
-          method = Method.GET,
-          uri = Uri.fromString(s"https://bigquery.googleapis.com/bigquery/v2/projects/${TEST_PROJECT}/datasets/${testDataset}/tables")
-            .getOrElse(Uri()))
-            .withHeaders(auth)
-        resp <- Timer[IO].sleep(5.seconds).flatMap { _ =>
-          httpClient.run(req).use {
-            case Status.Successful(r) => r.attemptAs[String].leftMap(_.message).value
-            case r => r.as[String].map(b => Left(s"Request ${req} failed with status ${r.status.code} and body ${b}"))
-        }}
-        body = resp.fold(identity, identity)
-        result <- IO {
-           body.contains(tableName) must beTrue
-        }
-      } yield result
-    }
+      val columns = PushColumns.NoPrimary(NonEmptyList.of(
+        Column("tag", ColumnType.String),
+        Column("value", ColumnType.Number)))
 
-    "successfully check table contents" >>* {
       for {
-        accessToken <- GBQAccessToken.token[IO](gbqConfig.serviceAccountAuthBytes)
+        (config, tableName) <- configAndTableF
+        path = ResourcePath.root() / ResourceName(tableName) / ResourceName("bar.csv")
+        args = AppendSink.Args(path, columns, WriteMode.Replace)
+        accessToken <- GBQAccessToken.token[IO](config.serviceAccountAuthBytes)
         auth = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken.getTokenValue))
-        req = Request[IO](
-          method = Method.GET,
-          uri = Uri.fromString(s"https://bigquery.googleapis.com/bigquery/v2/projects/${TEST_PROJECT}/datasets/${testDataset}/tables/${tableName}/data")
-            .getOrElse(Uri()))
-            .withHeaders(auth)
-        resp <- Timer[IO].sleep(5.seconds).flatMap { _ =>
-          httpClient.run(req).use {
-            case Status.Successful(r) => r.attemptAs[String].leftMap(_.message).value
-            case r => r.as[String].map(b => Left(s"Request ${req} failed with status ${r.status.code} and body ${b}"))
-        }}
-        body = resp.fold(identity, identity)
-        result <- IO {
-          body.contains("stuff") must beTrue
-        }
-      } yield result
-    }
 
-    "successfully cleanup dataset and tables" >>* {
-      for {
-        accessToken <- GBQAccessToken.token[IO](gbqConfig.serviceAccountAuthBytes)
-        auth = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken.getTokenValue))
-        req = Request[IO](
-          method = Method.DELETE,
-          uri = Uri.fromString(s"https://bigquery.googleapis.com/bigquery/v2/projects/${TEST_PROJECT}/datasets/${testDataset}?deleteContents=true")
-            .getOrElse(Uri()))
-            .withHeaders(auth)
-        resp <- Timer[IO].sleep(5.seconds).flatMap { _ =>
-          httpClient.run(req).use {
-            case Status.Successful(r) => IO { r.status }
-            case r => IO { r.status }
-        }}
-        result <- IO {
-          resp must beLike {
-            case Status.NoContent => ok
+        r <- append(config.asJson).use { mkConsumer =>
+          for {
+            res0 <- data0.through(mkConsumer(args).apply[String]).compile.toList
+            _ <- waitABit
+
+            rows0 <- getContent[Rows](config.datasetId, tableName, auth)
+
+            res1 <- data1.through(mkConsumer(args.copy(writeMode = WriteMode.Append)).apply[String])
+              .compile.toList
+            _ <- waitABit
+
+            rows1 <- getContent[Rows](config.datasetId, tableName, auth)
+
+            _ <- deleteDataset(config.datasetId, auth)
+
+          } yield {
+            val rowsExpected0 = List(
+              Row("a", 1),
+              Row("b", 2),
+              Row("c", 3))
+
+            val rowsExpected1 = rowsExpected0 ++ List(
+              Row("d", 4),
+              Row("e", 5))
+
+            rows0 must_=== Rows(rowsExpected0)
+            rows1 must_=== Rows(rowsExpected1)
+            res0 must_=== List(OffsetKey.Actual.string("commit0"))
+            res1 must_=== List(OffsetKey.Actual.string("commit1"), OffsetKey.Actual.string("commit2"))
           }
         }
-      } yield result
+      } yield r
+    }
+
+    "upsert sink upload tables and upsert data" >>* {
+      val data0: Stream[IO, DataEvent[Byte, OffsetKey.Actual[String]]] = Stream(
+        DataEvent.Create(Chunk.array("a,1\r\n".getBytes)),
+        DataEvent.Create(Chunk.array("b,2\r\nc,3\r\n".getBytes)),
+        DataEvent.Commit(OffsetKey.Actual.string("commit0")))
+
+      val data1: Stream[IO, DataEvent[Byte, OffsetKey.Actual[String]]] = Stream(
+        DataEvent.Create(Chunk.array("d,4\r\n".getBytes)),
+        DataEvent.Commit(OffsetKey.Actual.string("commit1")),
+        DataEvent.Create(Chunk.array("e,5\r\n".getBytes)),
+        DataEvent.Commit(OffsetKey.Actual.string("commit2")))
+
+      val data2: Stream[IO, DataEvent[Byte, OffsetKey.Actual[String]]] = Stream(
+        DataEvent.Delete(IdBatch.Strings(Array("b", "d"), 2)),
+        DataEvent.Create(Chunk.array("b,40\r\ne,21\r\nh,42".getBytes)),
+        DataEvent.Commit(OffsetKey.Actual.string("commit3")))
+
+
+      for {
+        (config, tableName) <- configAndTableF
+
+        path = ResourcePath.root() / ResourceName(tableName) / ResourceName("quux.csv")
+
+        args = UpsertSink.Args[ColumnType.Scalar](
+          path,
+          Column("Tag", ColumnType.String),
+          List(Column("Value", ColumnType.Number)),
+          WriteMode.Replace)
+
+        accessToken <- GBQAccessToken.token[IO](config.serviceAccountAuthBytes)
+        auth = Authorization(Credentials.Token(AuthScheme.Bearer, accessToken.getTokenValue))
+
+        r <- upsert(config.asJson).use { mkConsumer =>
+          for {
+            res0 <- data0.through(mkConsumer(args).apply[String]).compile.toList
+            _ <- waitABit
+
+            rows0 <- getContent[Rows](config.datasetId, tableName, auth)
+
+            res1 <- data1.through(mkConsumer(args.copy(writeMode = WriteMode.Append)).apply[String])
+              .compile.toList
+            _ <- waitABit
+
+            rows1 <- getContent[Rows](config.datasetId, tableName, auth)
+
+            res2 <- data2.through(mkConsumer(args.copy(writeMode = WriteMode.Append)).apply[String])
+              .compile.toList
+            _ <- waitABit
+
+            rows2 <- getContent[Rows](config.datasetId, tableName, auth)
+
+            _ <- deleteDataset(config.datasetId, auth)
+          } yield {
+            val rowsExpected0 = List(
+              Row("a", 1),
+              Row("b", 2),
+              Row("c", 3))
+
+            val rowsExpected1 = rowsExpected0 ++ List(
+              Row("d", 4),
+              Row("e", 5))
+
+            val rowsExpected2 = List(
+              Row("e", 5),
+              Row("a", 1),
+              Row("c", 3),
+              Row("b", 40),
+              Row("e", 21),
+              Row("h", 42))
+
+            rows0 must_=== Rows(rowsExpected0)
+            rows1 must_=== Rows(rowsExpected1)
+            rows2 must_=== Rows(rowsExpected2)
+            res0 must_=== List(OffsetKey.Actual.string("commit0"))
+            res1 must_=== List(OffsetKey.Actual.string("commit1"), OffsetKey.Actual.string("commit2"))
+            res2 must_=== List(OffsetKey.Actual.string("commit3"))
+          }
+        }
+      } yield r
+
+    }
+  }
+
+  def getContent[A: EntityDecoder[IO, *]](dataset: String, tableName: String, auth: Header): IO[A] = {
+      val contentRequest = Request[IO](
+        method = Method.GET,
+        uri = Uri.fromString(s"$UriRoot/$dataset/tables/$tableName/data")
+          .getOrElse(Uri()))
+          .withHeaders(auth)
+      httpClient.run(contentRequest).use {
+        case Status.Successful(r) => r.as[A]
+        case r => IO.raiseError(new Throwable("Content request errored"))
+      }
+  }
+
+  def deleteDataset(dataset: String, auth: Header): IO[Boolean] = {
+    val deleteReq = Request[IO](
+      method = Method.DELETE,
+      uri = Uri.fromString(s"$UriRoot/${dataset}?deleteContents=true")
+        .getOrElse(Uri()))
+        .withHeaders(auth)
+    httpClient.run(deleteReq).use {
+      case Status.NoContent(r) => IO(true)
+      case r => IO(false)
     }
   }
 
   implicit val MRE: MonadError_[IO, ResourceError] =
     MonadError_.facet[IO](ResourceError.throwableP)
 
-    def csv[A](
-        gbqcfg: Json)(
-          f: ((ResourcePath, NonEmptyList[Column[ColumnType.Scalar]]) => Pipe[IO, Byte, Unit]) => IO[A])
-        : IO[A] =
-    dest(gbqcfg) {
-      case Left(err) =>
-        IO.raiseError(new RuntimeException(err.toString))
-      case Right(dst) =>
-        dst.sinks.toList
-          .collectFirst {
-            case c @ ResultSink.CreateSink(_) => c
-          }
-          .map { s =>
-            val sink = s.asInstanceOf[ResultSink.CreateSink[IO, ColumnType.Scalar, Byte]]
-            f(sink.consume(_, _)._2)
-          }
-          .getOrElse(IO.raiseError(new RuntimeException("No CSV sink found!")))
-    }
-
-  def dest[A](cfg: Json)(f: Either[InitializationError[Json], Destination[IO]] => IO[A]): IO[A] = {
+  def dest(cfg: Json): Resource[IO, Destination[IO]] = {
     val pushPull: PushmiPullyu[IO] = _ => _ => Stream.empty[IO]
-
-    GBQDestinationModule.destination[IO](cfg, pushPull).use(f)
+    GBQDestinationModule.destination[IO](cfg, pushPull) evalMap {
+      case Left(e) => IO.raiseError(new Throwable("Incorrect config"))
+      case Right(a) => IO.pure(a)
+    }
   }
+
+  type CreateConsumer = (ResourcePath, NonEmptyList[Column[ColumnType.Scalar]]) => Pipe[IO, Byte, Unit]
+
+  def csv(gbqcfg: Json): Resource[IO, CreateConsumer] = dest(gbqcfg) evalMap { dst =>
+    dst.sinks.toList
+      .collectFirst({
+        case c @ ResultSink.CreateSink(_) => c
+      })
+      .map({ s =>
+        val sink = s.asInstanceOf[ResultSink.CreateSink[IO, ColumnType.Scalar, Byte]]
+        val consumer: CreateConsumer = sink.consume(_, _)._2
+        IO(consumer)
+      })
+      .getOrElse(IO.raiseError(new Throwable("No Create CSV sink found")))
+  }
+
+  type UpsertConsumer =
+    UpsertSink.Args[ColumnType.Scalar] =>
+      ∀[λ[α => Pipe[IO, DataEvent[Byte, OffsetKey.Actual[α]], OffsetKey.Actual[α]]]]
+
+  def upsert(gbqcfg: Json): Resource[IO, UpsertConsumer] = dest(gbqcfg) evalMap { dst =>
+    dst.sinks.toList
+      .collectFirst({
+        case c @ ResultSink.UpsertSink(_) => c
+      })
+      .map({ s =>
+        val sink = s.asInstanceOf[ResultSink.UpsertSink[IO, ColumnType.Scalar, Byte]]
+        val consumer: UpsertConsumer = sink.consume(_)._2
+        IO(consumer)
+      })
+      .getOrElse(IO.raiseError(new Throwable("No Upsert CSV sink found")))
+  }
+
+  type AppendConsumer =
+    AppendSink.Args[ColumnType.Scalar] =>
+      ∀[λ[α => Pipe[IO, AppendEvent[Byte, OffsetKey.Actual[α]], OffsetKey.Actual[α]]]]
+
+  def append(gbqcfg: Json): Resource[IO, AppendConsumer] = dest(gbqcfg) evalMap { dst =>
+    dst.sinks.toList
+      .collectFirst({
+        case c @ ResultSink.AppendSink(_) => c
+      })
+      .map({ s =>
+        val consume: AppendConsumer = { (x: AppendSink.Args[ColumnType.Scalar]) =>
+          s.asInstanceOf[ResultSink.AppendSink[IO, ColumnType.Scalar]]
+            .consume(x)
+            .pipe
+            .asInstanceOf[∀[λ[α => Pipe[IO, AppendEvent[Byte, OffsetKey.Actual[α]], OffsetKey.Actual[α]]]]]
+        }
+        IO(consume)
+      })
+      .getOrElse(IO.raiseError(new Throwable("No Append CSV sink found")))
+  }
+
 }


### PR DESCRIPTION
[ch13093] 

+ CDC
+ Split incoming stream to make bunch of uploads, if I understand correctly data can't be sent to GBQ w/o having file size => we need to grab whole input stream in RAM and calculate it. With implemented approach we split input stream to 1Gb streams which are uploaded. 

I'm not really sure if `GBQFlow` methods need semaphore for securing access token from modification during http request. In our current workflow this shouldn't be a problem probably. 