### PR TITLE
Lazy token

### DIFF
--- a/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
@@ -255,7 +255,7 @@ final class GBQFlow[F[_]: Concurrent](
                 .as(loc.uri.asRight[InitializationError[Json]])
           }
           case otherStatus =>  
-            resp.attemptAs[String].fold(
+            resp.attemptAs[String].foldF(
                 _ => Sync[F].delay(log.error(s"GBQ job creation failed with status '$otherStatus' and no body")),
                 body => Sync[F].delay(log.error(s"GBQ job creation failed with status '$otherStatus': $body")))
               .as(DestinationError.invalidConfiguration(

--- a/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
@@ -256,7 +256,7 @@ final class GBQFlow[F[_]: Concurrent](
           }
           case otherStatus =>  
             resp.attemptAs[String].foldF(
-                _ => Sync[F].delay(log.error(s"GBQ job creation failed with status '$otherStatus' and failed to decode response: ${err.message}")),
+                err => Sync[F].delay(log.error(s"GBQ job creation failed with status '$otherStatus' and failed to decode response: ${err.message}")),
                 response => Sync[F].delay(log.error(s"GBQ job creation failed with status '$otherStatus' and response: $response")))
               .as(DestinationError.invalidConfiguration(
                 (GBQDestinationModule.destinationType, 

--- a/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
+++ b/core/src/main/scala/quasar/destination/gbq/GBQFlow.scala
@@ -58,6 +58,7 @@ import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
 
 import com.google.auth.oauth2.AccessToken
+import fs2.Pull
 
 final class GBQFlow[F[_]: Concurrent](
     name: String,
@@ -84,19 +85,16 @@ final class GBQFlow[F[_]: Concurrent](
     GBQAccessToken.token(config.serviceAccountAuthBytes)
 
   def ingest: Pipe[F, Byte, Unit] = { (bytes: Stream[F, Byte]) =>
+
+    val uploadUri = for {
+      mode <- refMode.get
+      jobConfig = formGBQJobConfig(schema, config, name, mode)
+      _ <- mkDataset.whenA(mode === WriteMode.Replace)
+      eloc <- mkGbqJob(jobConfig)
+    } yield eloc
+
     for {
-      eitherloc <- Stream.eval {
-        for {
-          mode <- refMode.get
-          jobConfig = formGBQJobConfig(schema, config, name, mode)
-          _ <- mkDataset.whenA(mode === WriteMode.Replace)
-          eloc <- mkGbqJob(jobConfig)
-        } yield eloc
-      }
-      _ <- eitherloc match {
-        case Right(locationUri) => upload(bytes, locationUri)
-        case Left(e) => Stream.raiseError[F](new RuntimeException(s"No Location URL returned from job: $e"))
-      }
+      _ <- upload(bytes, uploadUri)
       _ <- Stream.eval(refMode.set(WriteMode.Append))
     } yield ()
   }
@@ -269,18 +267,40 @@ final class GBQFlow[F[_]: Concurrent](
     })
   }
 
-  private def upload(bytes: Stream[F, Byte], uploadLocation: Uri): Stream[F, Unit] = {
-    val destReq = Request[F](Method.PUT, uploadLocation)
-        .putHeaders(Header("Host", "www.googleapis.com"))
-        .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
-        .withEntity(bytes)
-    client.stream(destReq) evalMap { resp =>
-      resp.status match {
-        case Status.Ok => ().pure[F]
-        case _ => ApplicativeError[F, Throwable].raiseError[Unit](
-            new RuntimeException(s"Upload failed: ${resp.status.reason}" ))
-      }
-    }
+  private def upload(bytes: Stream[F, Byte], uploadLocation: F[Either[InitializationError[Json], Uri]]): Stream[F, Unit] = {
+
+    bytes.pull.uncons.flatMap {
+      case None => 
+        Pull.done
+      case Some((firstChunk, restOfStream)) => 
+        Pull.eval(uploadLocation).flatMap {
+          case Left(error) => 
+            Pull.raiseError[F](new RuntimeException(s"No Location URL returned from job: $error"))
+            
+          case Right(uri) =>
+
+            val entity = (Stream.chunk(firstChunk) ++ restOfStream)
+
+            val destReq = Request[F](Method.PUT, uri)
+                .putHeaders(Header("Host", "www.googleapis.com"))
+                .withContentType(`Content-Type`(MediaType.application.`x-www-form-urlencoded`))
+                .withEntity(entity)
+
+            val uploadStream = client.stream(destReq) evalMap { resp =>
+              resp.status match {
+                case Status.Ok => ().pure[F]
+                case _ => ApplicativeError[F, Throwable].raiseError[Unit](
+                    new RuntimeException(s"Upload failed: ${resp.status.reason}" ))
+              }
+            }
+
+            uploadStream.pull.echo
+
+        }
+        
+    }.stream
+
+
   }
 }
 


### PR DESCRIPTION
The job URI is now created once the first bytes are received, instead of being done eagerly. This is because some sources don't send bytes for a long time, causing the URI to become stale.

resolves precog/features#82